### PR TITLE
Show existing shared plans in quick view box

### DIFF
--- a/cypress/FakeSVapi.js
+++ b/cypress/FakeSVapi.js
@@ -47,4 +47,8 @@ app.post('/customers/:id/shared-plans', (req, res) => {
   res.status(201).send({ id: '1' });
 });
 
+app.get('/customers/:id/shared-plans', (req, res) => {
+  res.status(201).send({ planIds: ['1'] });
+});
+
 app.listen(port, () => console.log(`Fake SV API listening on port ${port}!`));

--- a/cypress/FakeSVapi.js
+++ b/cypress/FakeSVapi.js
@@ -48,7 +48,7 @@ app.post('/customers/:id/shared-plans', (req, res) => {
 });
 
 app.get('/customers/:id/shared-plans', (req, res) => {
-  res.status(201).send({ planIds: ['1'] });
+  res.status(200).send({ planIds: ['1'] });
 });
 
 app.listen(port, () => console.log(`Fake SV API listening on port ${port}!`));

--- a/cypress/integration/pages/details.spec.js
+++ b/cypress/integration/pages/details.spec.js
@@ -85,4 +85,16 @@ describe('Details Page', () => {
         .and('contain', '12345');
     });
   });
+
+  describe.only('Shared plans', () => {
+    const selector = '[data-testid="shared-plan-quickview"]';
+
+    it('displays the Shared Plans quick view box', () => {
+      cy.get(selector).should('exist');
+    });
+
+    it('displays a list of existing plans', () => {
+      cy.get(`${selector} ul`).should('not.be.empty');
+    });
+  });
 });

--- a/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/SharedPlansList.module.scss
+++ b/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/SharedPlansList.module.scss
@@ -1,0 +1,8 @@
+.wrapper {
+  margin-bottom: 1rem;
+  
+  .heading {
+    margin-bottom: 0.2rem;
+    font-weight: bold;
+  }
+}

--- a/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/index.jsx
+++ b/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/index.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import findSharedPlans from '../../../../../Gateways/FindSharedPlans';
+import styles from './SharedPlansList.module.scss';
+
+const SharedPlansList = ({ customerId }) => {
+  const [state, setState] = useState({
+    plans: [],
+    loading: true,
+    error: null
+  });
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const plans = await findSharedPlans({ customerId });
+        setState({ plans, loading: false });
+      } catch (error) {
+        setState({ error, loading: false });
+      }
+    };
+
+    fetch();
+  }, [customerId]);
+
+  if (state.loading) {
+    return null;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <h4 className={styles.heading}>Existing plans</h4>
+      <ul>
+        {state.plans.map(({ id, location }) => (
+          <li key={id}>
+            <a href={location}>{id}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SharedPlansList;

--- a/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/index.jsx
+++ b/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/index.jsx
@@ -15,14 +15,14 @@ const SharedPlansList = ({ customerId }) => {
         const plans = await findSharedPlans({ customerId });
         setState({ plans, loading: false });
       } catch (error) {
-        setState({ error, loading: false });
+        setState({ plans: [], error, loading: false });
       }
     };
 
     fetch();
   }, [customerId]);
 
-  if (state.loading) {
+  if (state.plans.length === 0) {
     return null;
   }
 

--- a/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/index.jsx
+++ b/src/app/Components/Details/QuickAccess/SharedPlan/SharedPlansList/index.jsx
@@ -30,9 +30,9 @@ const SharedPlansList = ({ customerId }) => {
     <div className={styles.wrapper}>
       <h4 className={styles.heading}>Existing plans</h4>
       <ul>
-        {state.plans.map(({ id, location }) => (
+        {state.plans.map(({ id, location }, i) => (
           <li key={id}>
-            <a href={location}>{id}</a>
+            <a href={location}>Plan {i + 1}</a>
           </li>
         ))}
       </ul>

--- a/src/app/Components/Details/QuickAccess/SharedPlan/index.jsx
+++ b/src/app/Components/Details/QuickAccess/SharedPlan/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import CreatePlanButton from './CreatePlanButton';
+import SharedPlansList from './SharedPlansList';
 
 const SharedPlanQuickBox = ({ customerId }) => (
-  <div className="quick-access__item">
+  <div className="quick-access__item" data-testid="shared-plan-quickview">
     <h3>Shared Plans</h3>
+    <SharedPlansList customerId={customerId} />
     <CreatePlanButton customerId={customerId} />
   </div>
 );

--- a/src/app/Gateways/FindSharedPlans.js
+++ b/src/app/Gateways/FindSharedPlans.js
@@ -1,0 +1,24 @@
+import { hackneyToken } from '../lib/Cookie';
+
+export default async ({ customerId }) => {
+  const response = await fetch(
+    `${process.env.REACT_APP_HN_API_URL}/customers/${customerId}/shared-plans`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${hackneyToken()}`
+      }
+    }
+  );
+
+  if (response.ok) {
+    const { planIds } = await response.json();
+
+    return planIds.map(id => ({
+      id,
+      location: `${process.env.REACT_APP_SHARED_PLAN_URL}/${id}`
+    }));
+  }
+
+  throw new Error(`Failed to find plans, status: ${response.status}`);
+};


### PR DESCRIPTION
**What**
Shows any existing shared plans in the "Shared Plan" quick view box alongside the button to create a new plan.

![image](https://user-images.githubusercontent.com/5405916/82563272-a8dd3a80-9b6e-11ea-9073-241ddcfd5e25.png)

**Why**
So that officers can easily access existing shared plans for a customer.

**Extras**
 - There is a [related PR for the API endpoint](https://github.com/LBHackney-IT/housing-needs-single-view-api/pull/89) required to support this.
