### PR TITLE
Update feature flags to have expiry rather than session

### DIFF
--- a/src/app/lib/FeatureFlag.js
+++ b/src/app/lib/FeatureFlag.js
@@ -15,7 +15,7 @@ const setFeatureFlag = featureKey => {
   if (hasFeatureFlag(featureKey)) return;
   const features = getFeatureFlags();
   features.push(featureKey);
-  Cookies.set(cookieName, features);
+  Cookies.set(cookieName, features, { expires: 365 });
 };
 
 const hasFeatureFlag = featureKey => {

--- a/src/app/lib/FeatureFlag.test.js
+++ b/src/app/lib/FeatureFlag.test.js
@@ -6,19 +6,22 @@ describe('FeatureFlag', () => {
   describe('setFeatureFlag', () => {
     it('can set a feature flag', () => {
       setFeatureFlag('my-new-feature');
-      expect(Cookies.set).toHaveBeenCalledWith('singleViewFeatures', [
-        'my-new-feature'
-      ]);
+      expect(Cookies.set).toHaveBeenCalledWith(
+        'singleViewFeatures',
+        ['my-new-feature'],
+        { expires: 365 }
+      );
     });
 
     it('can set a feature flag when there are other flags', () => {
       Cookies.get.mockImplementation(() => '["my-new-feature"]');
       setFeatureFlag('my-newer-feature');
       expect(Cookies.get).toHaveBeenCalled();
-      expect(Cookies.set).toHaveBeenCalledWith('singleViewFeatures', [
-        'my-new-feature',
-        'my-newer-feature'
-      ]);
+      expect(Cookies.set).toHaveBeenCalledWith(
+        'singleViewFeatures',
+        ['my-new-feature', 'my-newer-feature'],
+        { expires: 365 }
+      );
     });
 
     it('does not create duplicate flags', () => {


### PR DESCRIPTION
WHAT
At the mo the feature flags only last for a session, with this update they'll last for eternity (365 days)