### PR TITLE
Include vulnerability snapshots in activity feed

### DIFF
--- a/cypress/fixtures/snapshot.json
+++ b/cypress/fixtures/snapshot.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "js783hdi",
+    "createdDate": "2020-06-16T15:46:32.0000Z",
     "vulnerabilities": [
       {
         "text": "Health condition"
@@ -18,6 +19,7 @@
   },
   {
     "id": "jad928hd",
+    "createdDate": "2019-07-14T11:16:30.0000Z",
     "vulnerabilities": [
       {
         "text": "Health condition"

--- a/src/app/Components/Details/Note/NoteContent.jsx
+++ b/src/app/Components/Details/Note/NoteContent.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const NoteContent = ({ text, trimmed, trimmedLength = 128 }) => {
+  if (!text) {
+    return null;
+  }
+
+  let content = text;
+  if (trimmed && text.length > trimmedLength) {
+    content = `${text.substring(0, 128)} ...`;
+  }
+
+  return (
+    <p style={{ overflowWrap: 'break-word', maxWidth: '350px' }}>{content}</p>
+  );
+};
+
+export default NoteContent;

--- a/src/app/Components/Details/Note/SnapshotNoteContent.jsx
+++ b/src/app/Components/Details/Note/SnapshotNoteContent.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styles from './SnapshotNoteContent.module.scss';
+
+const buildUrl = (id) => [process.env.REACT_APP_VULNERABILITIES_APP_URL, id].join('/');
+
+const SnapshotNoteContent = ({
+  snapshot: { id, vulnerabilities, assets, notes }
+}) => (
+    <div className={styles.snapshot}>
+      <p>
+        <strong>Vulnerabilities:</strong>{' '}
+        {vulnerabilities.map(({ text }) => text).join(', ')}
+      </p>
+      <p>
+        <strong>Strengths / assets:</strong>{' '}
+        {assets.map(({ text }) => text).join(', ')}
+      </p>
+      {notes && (
+        <p className={styles.note}>
+          <strong>Additional note:</strong> {notes}
+        </p>
+      )}
+
+      <a className={styles.link} href={buildUrl(id)}>
+        View full vulnerabilities snapshot
+      </a>
+    </div>
+  );
+
+export default SnapshotNoteContent;

--- a/src/app/Components/Details/Note/SnapshotNoteContent.jsx
+++ b/src/app/Components/Details/Note/SnapshotNoteContent.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styles from './SnapshotNoteContent.module.scss';
 
-const buildUrl = (id) => [process.env.REACT_APP_VULNERABILITIES_APP_URL, id].join('/');
+const buildUrl = id =>
+  [process.env.REACT_APP_VULNERABILITIES_APP_URL, 'snapshots', id].join('/');
 
 const SnapshotNoteContent = ({
   snapshot: { id, vulnerabilities, assets, notes }

--- a/src/app/Components/Details/Note/SnapshotNoteContent.module.scss
+++ b/src/app/Components/Details/Note/SnapshotNoteContent.module.scss
@@ -1,0 +1,14 @@
+div.snapshot {
+  p > strong {
+    color: inherit;
+  }
+
+  p.note {
+    margin-top: 1.5em!important; /* 😠 */
+  }
+
+  a.link {
+    display: block;
+    margin-top: 1em!important; /* 😠😠 */
+  }
+}

--- a/src/app/Components/Details/Note/index.jsx
+++ b/src/app/Components/Details/Note/index.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import moment from 'moment';
 import DocumentModal from '../../DocumentModal';
 import NoteContent from './NoteContent';
+import SnapshotNoteContent from './SnapshotNoteContent';
 
 export default class Note extends Component {
   constructor(props) {
@@ -53,6 +54,21 @@ export default class Note extends Component {
     }
   };
 
+  renderNoteContent = () => {
+    switch (this.props.note.type) {
+      case 'snapshot':
+        return <SnapshotNoteContent snapshot={this.props.note} />;
+      default:
+        return (
+          <NoteContent
+            text={this.props.note.text}
+            trimmed={!this.state.expanded}
+            trimmedLength={this.maxNoteLength}
+          />
+        );
+    }
+  };
+
   render() {
     return (
       <tr>
@@ -69,11 +85,7 @@ export default class Note extends Component {
                 )}
             </strong>
           </p>
-          <NoteContent
-            text={this.props.note.text}
-            trimmed={!this.state.expanded}
-            trimmedLength={this.maxNoteLength}
-          />
+          {this.renderNoteContent()}
           {this.expandButton()}
           <DocumentModal
             open={this.state.showDoc}

--- a/src/app/Components/Details/Note/index.jsx
+++ b/src/app/Components/Details/Note/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import moment from 'moment';
 import DocumentModal from '../../DocumentModal';
+import NoteContent from './NoteContent';
 
 export default class Note extends Component {
   constructor(props) {
@@ -27,35 +28,19 @@ export default class Note extends Component {
   }
 
   click = () => {
-    this.setState({
-      showDoc: true
-    });
+    this.setState({ showDoc: true });
   };
 
   closeDoc = () => {
-    this.setState({
-      showDoc: false
-    });
+    this.setState({ showDoc: false });
   };
 
   toggleNote = () => {
-    this.setState({
-      expanded: !this.state.expanded
-    });
-  };
-
-  noteText = () => {
-    if (
-      this.props.note.text.length > this.maxNoteLength &&
-      !this.state.expanded
-    ) {
-      return `${this.props.note.text.substring(0, 128)} ...`;
-    }
-    return this.props.note.text;
+    this.setState({ expanded: !this.state.expanded });
   };
 
   expandButton = () => {
-    if (this.props.note.text.length > this.maxNoteLength) {
+    if (this.props.note.text?.length > this.maxNoteLength) {
       const className = this.state.expanded
         ? 'govuk-details__summary govuk-details__summary__arrow-up'
         : 'govuk-details__summary';
@@ -80,13 +65,15 @@ export default class Note extends Component {
                   {this.props.note.title}
                 </button>
               ) : (
-                this.props.note.title
-              )}
+                  this.props.note.title
+                )}
             </strong>
           </p>
-          <p style={{ overflowWrap: 'break-word', maxWidth: '350px' }}>
-            {this.noteText()}
-          </p>
+          <NoteContent
+            text={this.props.note.text}
+            trimmed={!this.state.expanded}
+            trimmedLength={this.maxNoteLength}
+          />
           {this.expandButton()}
           <DocumentModal
             open={this.state.showDoc}

--- a/src/app/Gateways/FindLatestSnapshot.js
+++ b/src/app/Gateways/FindLatestSnapshot.js
@@ -1,24 +1,12 @@
-import { hackneyToken } from '../lib/Cookie';
+import findSnapshots from './FindSnapshots';
 
 export default async ({ customerId }) => {
-  const response = await fetch(
-    `${process.env.REACT_APP_HN_API_URL}/customers/${customerId}/vulnerabilities`,
-    {
-      method: 'GET',
-      headers: { Authorization: `Bearer ${hackneyToken()}` }
-    }
-  );
+  const { success, data } = await findSnapshots({ customerId });
 
-  if (response.ok) {
-    const data = await response.json();
+  if (success) {
     return {
+      success,
       data: data.length > 0 ? data[0] : null,
-      success: true
-    };
-  } else if (response.status === 404) {
-    return {
-      data: null,
-      success: true
     };
   }
 

--- a/src/app/Gateways/FindLatestSnapshot.test.js
+++ b/src/app/Gateways/FindLatestSnapshot.test.js
@@ -1,14 +1,8 @@
 import findLatestSnapshot from './FindLatestSnapshot';
 import { enableFetchMocks } from 'jest-fetch-mock';
-import { hackneyToken } from '../lib/Cookie';
-jest.mock('../lib/Cookie');
 
 describe('FindLatestSnapshot', () => {
-  beforeEach(() => {
-    enableFetchMocks();
-    hackneyToken.mockImplementation(() => 'token');
-    process.env.REACT_APP_HN_API_URL = 'http://svapi';
-  });
+  beforeEach(() => enableFetchMocks());
 
   it('can find the latest snapshot', async () => {
     const expectedSnapshot = {
@@ -20,14 +14,6 @@ describe('FindLatestSnapshot', () => {
     fetch.mockResponse(JSON.stringify([expectedSnapshot]));
     const result = await findLatestSnapshot({ customerId: 1 });
 
-    expect(fetch).toHaveBeenCalledWith(
-      'http://svapi/customers/1/vulnerabilities',
-      {
-        method: 'GET',
-        headers: { Authorization: 'Bearer token' }
-      }
-    );
-
     expect(result).toEqual({
       success: true,
       data: expectedSnapshot
@@ -36,7 +22,6 @@ describe('FindLatestSnapshot', () => {
 
   it('returns null if no snapshot is found', async () => {
     fetch.mockImplementationOnce(() => ({ ok: false, status: 404 }));
-
     const result = await findLatestSnapshot({ customerId: 1 });
 
     expect(result).toEqual({
@@ -47,7 +32,6 @@ describe('FindLatestSnapshot', () => {
 
   it('sets success to false if call fails', async () => {
     fetch.mockImplementationOnce(() => ({ ok: false, status: 500 }));
-
     const result = await findLatestSnapshot({ customerId: 1 });
 
     expect(result).toEqual({

--- a/src/app/Gateways/FindSnapshots.js
+++ b/src/app/Gateways/FindSnapshots.js
@@ -1,0 +1,25 @@
+import { hackneyToken } from '../lib/Cookie';
+
+export default async ({ customerId }) => {
+  const response = await fetch(
+    `${process.env.REACT_APP_HN_API_URL}/customers/${customerId}/vulnerabilities`,
+    {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${hackneyToken()}` }
+    }
+  );
+
+  if (response.ok) {
+    return {
+      data: await response.json(),
+      success: true
+    };
+  } else if (response.status === 404) {
+    return {
+      data: [],
+      success: true
+    };
+  }
+
+  return { data: [], success: false };
+};

--- a/src/app/Gateways/FindSnapshots.test.js
+++ b/src/app/Gateways/FindSnapshots.test.js
@@ -1,0 +1,58 @@
+import findSnapshots from './FindSnapshots';
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { hackneyToken } from '../lib/Cookie';
+jest.mock('../lib/Cookie');
+
+describe('FindSnapshots', () => {
+  beforeEach(() => {
+    enableFetchMocks();
+    hackneyToken.mockImplementation(() => 'token');
+    process.env.REACT_APP_HN_API_URL = 'http://svapi';
+  });
+
+  it('can find the latest snapshot', async () => {
+    const expectedSnapshots = [
+      {
+        id: 'snap1',
+        vulnerabilities: [],
+        assets: [{ text: 'Passes the test!' }]
+      }
+    ];
+
+    fetch.mockResponse(JSON.stringify(expectedSnapshots));
+    const result = await findSnapshots({ customerId: 1 });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://svapi/customers/1/vulnerabilities',
+      {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: expectedSnapshots
+    });
+  });
+
+  it('returns empty list if nothing found', async () => {
+    fetch.mockImplementationOnce(() => ({ ok: false, status: 404 }));
+    const result = await findSnapshots({ customerId: 1 });
+
+    expect(result).toEqual({
+      success: true,
+      data: []
+    });
+  });
+
+  it('sets success to false if call fails', async () => {
+    fetch.mockImplementationOnce(() => ({ ok: false, status: 500 }));
+    const result = await findSnapshots({ customerId: 1 });
+
+    expect(result).toEqual({
+      success: false,
+      data: []
+    });
+  });
+});

--- a/src/app/Gateways/index.js
+++ b/src/app/Gateways/index.js
@@ -4,6 +4,7 @@ import FetchCustomerRecord from './FetchCustomerRecord';
 import FetchCustomerDocuments from './FetchCustomerDocuments';
 import SearchCustomers from './SearchCustomers';
 import DeleteCustomerRecord from './DeleteCustomerRecord';
+import FindSnapshots from './FindSnapshots';
 
 export {
   CreateCustomer,
@@ -11,5 +12,6 @@ export {
   FetchCustomerRecord,
   FetchCustomerDocuments,
   SearchCustomers,
-  DeleteCustomerRecord
+  DeleteCustomerRecord,
+  FindSnapshots
 };


### PR DESCRIPTION
**What**
Adds vulnerability snapshots into the activity feed.
![image](https://user-images.githubusercontent.com/5405916/85046709-b1825a00-b188-11ea-86ff-a3e610e220bc.png)

**Why**
So that officers can see how vulnerability has changed over time and when vulnerabilities and strengths were last updated.

**Anything else?**
 - Refactored note text into a component to make it easier to add in a variation of this for vulnerability snapshot content.