### PR TITLE
Change vulnerabilities strings to objects

### DIFF
--- a/cypress/fixtures/snapshot.json
+++ b/cypress/fixtures/snapshot.json
@@ -4,17 +4,24 @@
       "id": "js783hdi",
       "createdDate": "2020-06-16T15:46:32.0000Z",
       "vulnerabilities": [
-        "Health condition",
-        "Active case with another service"
+        { "name": "Health condition", "data": [] },
+        { "name": "Active case with another service", "data": [] }
       ],
-      "assets": ["Close relationships with family/friends"],
+      "assets": [
+        {
+          "name": "Close relationships with family/friends",
+          "data": [{ "id": "For example", "value": "description" }]
+        }
+      ],
       "notes": "Updated during review meeting"
     },
     {
       "id": "jad928hd",
       "createdDate": "2019-07-14T11:16:30.0000Z",
-      "vulnerabilities": ["Health condition"],
-      "assets": ["Close relationships with family/friends"],
+      "vulnerabilities": [{ "name": "Health condition", "data": [] }],
+      "assets": [
+        { "name": "Other", "data": [{ "id": "Other", "value": "description" }] }
+      ],
       "notes": "Added during initial meeting with client"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cy:start": "node cypress/FakeSVapi.js & react-scripts start",
     "cy:run": "cypress run",
     "cypress": "start-server-and-test cy:start http://localhost:3001 cy:run",
-    "unit-test": "jest --runInBand"
+    "unit-test": "jest --runInBand --watch"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/app/Components/Details/Note/SnapshotNoteContent.jsx
+++ b/src/app/Components/Details/Note/SnapshotNoteContent.jsx
@@ -13,10 +13,12 @@ const SnapshotNoteContent = ({
   return (
     <div className={styles.snapshot}>
       <p>
-        <strong>Vulnerabilities:</strong> {vulnerabilities.join(', ')}
+        <strong>Vulnerabilities:</strong>{' '}
+        {vulnerabilities.map(vulnerability => vulnerability.name).join(', ')}
       </p>
       <p>
-        <strong>Strengths / assets:</strong> {assets.join(', ')}
+        <strong>Strengths / assets:</strong>{' '}
+        {assets.map(asset => asset.name).join(', ')}
       </p>
       {text && (
         <p className={styles.note} style={{ overflowWrap: 'break-word' }}>
@@ -27,7 +29,11 @@ const SnapshotNoteContent = ({
         </p>
       )}
       {expandBtn}
-      <a className={styles.link} href={buildUrl(id)}>
+      <a
+        className={styles.link}
+        href={buildUrl(id)}
+        data-testid="full-vulnerabilities-snapshot-link"
+      >
         View full vulnerabilities snapshot
       </a>
     </div>

--- a/src/app/Components/Details/ThingsToNote/SnapshotSummary/index.jsx
+++ b/src/app/Components/Details/ThingsToNote/SnapshotSummary/index.jsx
@@ -8,10 +8,10 @@ const ColorPointList = ({ items, type }) => (
       <li key={item.name}>
         {item.name}
         <ul className={classnames(styles.nested)}>
-          {item.data &&
-            Object.entries(item.data).map(([id, value], i) => (
-              <li key={`vuln-${i}-${id}`}>
-                {id}: {value}
+          {item.data.length > 0 &&
+            item.data.map((entry, i) => (
+              <li key={`vuln-${i}-${entry.id}`}>
+                {entry.id}: {entry.value}
               </li>
             ))}
         </ul>

--- a/src/app/Components/Details/ThingsToNote/SnapshotSummary/index.jsx
+++ b/src/app/Components/Details/ThingsToNote/SnapshotSummary/index.jsx
@@ -4,8 +4,18 @@ import styles from './index.module.scss';
 
 const ColorPointList = ({ items, type }) => (
   <ul className={classnames(styles.points, styles[type])}>
-    {items.map(text => (
-      <li key={text}>{text}</li>
+    {items.map(item => (
+      <li key={item.name}>
+        {item.name}
+        <ul className={classnames(styles.nested)}>
+          {item.data &&
+            Object.entries(item.data).map(([id, value], i) => (
+              <li key={`vuln-${i}-${id}`}>
+                {id}: {value}
+              </li>
+            ))}
+        </ul>
+      </li>
     ))}
   </ul>
 );

--- a/src/app/Components/Details/ThingsToNote/SnapshotSummary/index.module.scss
+++ b/src/app/Components/Details/ThingsToNote/SnapshotSummary/index.module.scss
@@ -24,6 +24,9 @@ ul.points {
       color: #ff6912;
     }
   }
+  .nested {
+    padding-left: 20px;
+  }
 }
 
 section {

--- a/src/app/Gateways/FindSnapshots.test.js
+++ b/src/app/Gateways/FindSnapshots.test.js
@@ -15,7 +15,9 @@ describe('FindSnapshots', () => {
       {
         id: 'snap1',
         vulnerabilities: [],
-        assets: [{ text: 'Passes the test!' }]
+        assets: [
+          { name: '', data: [{ id: 'text', value: 'Passes the test!' }] }
+        ]
       }
     ];
 


### PR DESCRIPTION
**What?**
Change vulnerabilities and assets strings to objects
<img width="311" alt="image" src="https://user-images.githubusercontent.com/54268893/86451223-819f8e80-bd12-11ea-8ac2-4b0393dd0dc8.png">

**Why?**
To be able to display the snapshots in the new format that comes from vulnerabilities