### PR TITLE
Add some styles for accessibility

### DIFF
--- a/src/app/Components/Phase/index.jsx
+++ b/src/app/Components/Phase/index.jsx
@@ -8,13 +8,13 @@ export default class Phase extends Component {
           <strong className="govuk-tag govuk-phase-banner__content__tag  lbh-tag">
             Beta
           </strong>
-          <span className="govuk-phase-banner__text">
+          <span id="feedback-banner" className="govuk-phase-banner__text">
             This is work in progress.{' '}
             <a
               href="https://docs.google.com/forms/d/e/1FAIpQLSdgiT3dktz647tu0T1MMAmoQwI0CvdIdIR6zQPB7Cyo0-mIqg/viewform"
               target="_blank"
               rel="noreferrer noopener"
-              aria-describedby="new-tab"
+              aria-describedby="feedback-banner"
             >
               Tell us what you think
               <img src="/assets/images/new-tab.png" alt="" width="10" />

--- a/src/app/Components/Tenant/index.jsx
+++ b/src/app/Components/Tenant/index.jsx
@@ -13,6 +13,7 @@ const tenant = props => {
           <a
             id="tenant-fullname-link"
             href={`/search?firstName=${props.forename}&lastName=${props.surname}`}
+            className="linkStyle"
             data-test="tenant-fullname-link"
           >
             {props.title} {props.forename} {props.surname}
@@ -37,7 +38,11 @@ const tenant = props => {
         >
           <p>
             Email:
-            <a id="tenant-email-link" href={`mailto:${props.email}`}>
+            <a
+              id="tenant-email-link"
+              href={`mailto:${props.email}`}
+              className="linkStyle"
+            >
               {props.email}
             </a>
           </p>

--- a/src/app/Pages/AddressResultsPage/index.jsx
+++ b/src/app/Pages/AddressResultsPage/index.jsx
@@ -12,6 +12,10 @@ export default class AddressResultsPage extends Component {
 
   render() {
     document.title = 'Search - Single View';
-    return <h1>Address results page!</h1>;
+    return (
+      <div className="lbh-container">
+        <h1>Address results page!</h1>
+      </div>
+    );
   }
 }

--- a/src/app/css/overrides.scss
+++ b/src/app/css/overrides.scss
@@ -187,9 +187,11 @@ p {
 }
 
 .govuk-back-link {
-  border: none;
-  font-weight: bold;
-  background: transparent;
+  border: none !important;
+  color: #00664f !important;
+  font-weight: bold !important;
+  text-decoration: none !important;
+  background: transparent !important;
 }
 
 .privacy-notice {
@@ -205,7 +207,7 @@ p {
   border: none;
   background: transparent;
   font-size: 100%;
-  color: #00664f;
+  color: #00664f !important;
   padding: 0 0 0 0;
   font-size: 16px;
 }


### PR DESCRIPTION
**What?**
Changed the link colours and added a valid aria describedBy for the feedback link. Moved the tenancy page header to the middle
<img width="798" alt="image" src="https://user-images.githubusercontent.com/54268893/92890395-fe37a300-f40e-11ea-9a6d-c56b97ab86da.png">


**Why**
To improve accessibility
