### PR TITLE
Updates to address results page and labels

### DIFF
--- a/cypress/fixtures/searchAddress.json
+++ b/cypress/fixtures/searchAddress.json
@@ -20,12 +20,16 @@
         {
           "firstName": "Andrew",
           "lastName": "King",
-          "dateOfBirth": "1928-10-12"
+          "dateOfBirth": "1928-10-12",
+          "responsible": true,
+          "title": "Mr"
         },
         {
-          "firstName": "Mr",
+          "firstName": "Tom",
           "lastName": "Sandman",
-          "dateOfBirth": "1950-03-05"
+          "dateOfBirth": "1950-03-05",
+          "responsible": true,
+          "title": "Mr"
         }
       ]
     },
@@ -49,7 +53,9 @@
         {
           "firstName": "Jean",
           "lastName": "Thomson",
-          "dateOfBirth": "1954-01-03"
+          "dateOfBirth": "1954-01-03",
+          "responsible": true,
+          "title": "Mrs"
         }
       ]
     },
@@ -71,9 +77,11 @@
       "otherCharge": "0.1",
       "residents": [
         {
-          "firstName": "Jean",
+          "firstName": "Elena",
           "lastName": "Thomson",
-          "dateOfBirth": "1954-01-03"
+          "dateOfBirth": "1954-01-03",
+          "responsible": true,
+          "title": "Ms"
         }
       ]
     }

--- a/cypress/integration/pages/searchAddressResults.spec.js
+++ b/cypress/integration/pages/searchAddressResults.spec.js
@@ -45,7 +45,7 @@ describe('Results Page', () => {
       );
       cy.get(
         '[data-testid=address-row-0] > td:nth-child(3) > p:nth-child(1)'
-      ).should('contain', 'Jean Thomson');
+      ).should('contain', 'Ms Elena Thomson');
     });
 
     it('Shows the date of birth', () => {

--- a/cypress/integration/pages/tenancyDetails/tenancyDetails.spec.js
+++ b/cypress/integration/pages/tenancyDetails/tenancyDetails.spec.js
@@ -106,8 +106,8 @@ describe('Tenancy Details Page', () => {
         .and('contain', 'The name');
     });
 
-    it('Displays the "Create process" button', () => {
-      cy.get('button#newTenancy').should('contain', 'Create process');
+    it('Displays the "Create new process" button', () => {
+      cy.get('button#newTenancy').should('contain', 'Create new process');
     });
 
     it('Does not display the "Create process" button if not in the correct group', () => {

--- a/src/app/Components/Details/TenancyProcesses/index.jsx
+++ b/src/app/Components/Details/TenancyProcesses/index.jsx
@@ -66,5 +66,5 @@ export default props => {
       </>
     );
   }
-  return <h2>There are no tasks</h2>;
+  return <h2>There are no processes and actions</h2>;
 };

--- a/src/app/Components/Results/AddressResults/index.jsx
+++ b/src/app/Components/Results/AddressResults/index.jsx
@@ -95,18 +95,32 @@ export default class AddressResults extends Component {
                   </td>
 
                   <td className="govuk-table__cell">
-                    {this.props.tenancies[i].residents.map(resident => (
-                      <p>{resident.firstName + ' ' + resident.lastName}</p>
-                    ))}
+                    {this.props.tenancies[i].residents.map(
+                      resident =>
+                        resident.responsible && (
+                          <p>
+                            {resident.title +
+                              ' ' +
+                              resident.firstName +
+                              ' ' +
+                              resident.lastName}
+                          </p>
+                        )
+                    )}
                   </td>
                   <td className="govuk-table__cell">
-                    {this.props.tenancies[i].residents.map(resident => (
-                      <p>
-                        {resident.dateOfBirth
-                          ? moment(resident.dateOfBirth).format('DD/MM/YYYY')
-                          : 'No date found'}
-                      </p>
-                    ))}
+                    {this.props.tenancies[i].residents.map(
+                      resident =>
+                        resident.responsible && (
+                          <p>
+                            {resident.dateOfBirth
+                              ? moment(resident.dateOfBirth).format(
+                                  'DD/MM/YYYY'
+                                )
+                              : 'No date found'}
+                          </p>
+                        )
+                    )}
                   </td>
                   <td className="govuk-table__cell">
                     {cleanTenureType(this.props.tenancies[i].tenureType)}

--- a/src/app/Components/Results/AddressResults/index.jsx
+++ b/src/app/Components/Results/AddressResults/index.jsx
@@ -99,11 +99,8 @@ export default class AddressResults extends Component {
                       resident =>
                         resident.responsible && (
                           <p>
-                            {resident.title +
-                              ' ' +
-                              resident.firstName +
-                              ' ' +
-                              resident.lastName}
+                            {resident.title} {resident.firstName}{' '}
+                            {resident.lastName}
                           </p>
                         )
                     )}

--- a/src/app/Pages/TenancyDetailsPage/index.jsx
+++ b/src/app/Pages/TenancyDetailsPage/index.jsx
@@ -125,7 +125,7 @@ export default class TenancyDetailsPage extends Component {
                   className="govuk-button lbh-button"
                   type="submit"
                 >
-                  Create process
+                  Create new process
                 </button>
               )}
             </div>


### PR DESCRIPTION
- Updated labels and results messages for searching by address results page
- Added title before tenant's name
- Removed household members from the search by address results (only tenants are shown)
- Updated cypress fixtures with 'responsible' and 'title' attributes
- Updated cypress tests